### PR TITLE
fix(sds-demo): update collaboration modal to use granular permissions

### DIFF
--- a/packages/sds-demo/rollup.config.js
+++ b/packages/sds-demo/rollup.config.js
@@ -137,11 +137,12 @@ module.exports = defineConfig((commandLineArguments) => {
           if (devMode) return // Skip in development (uses loopback client)
 
           // Detect deployment URL from environment
-          // VERCEL_URL is available during Vercel builds
-          // Fallback to VERCEL_PROJECT_PRODUCTION_URL or CLIENT_URL for custom config
+          // VERCEL_URL contains the current deployment URL (preview or production)
+          // VERCEL_PROJECT_PRODUCTION_URL contains the production URL (fallback)
+          // CLIENT_URL can be used for custom configurations
           const deploymentUrl =
-            process.env.VERCEL_PROJECT_PRODUCTION_URL ||
             process.env.VERCEL_URL ||
+            process.env.VERCEL_PROJECT_PRODUCTION_URL ||
             process.env.CLIENT_URL
 
           if (!deploymentUrl) {
@@ -176,9 +177,7 @@ module.exports = defineConfig((commandLineArguments) => {
             source: JSON.stringify(metadata, null, 2),
           })
 
-          console.log(
-            `Generated client-metadata.json for ${clientUrl}`,
-          )
+          console.log(`Generated client-metadata.json for ${clientUrl}`)
         },
       },
 

--- a/packages/sds-demo/src/components/collaboration-modal.tsx
+++ b/packages/sds-demo/src/components/collaboration-modal.tsx
@@ -7,7 +7,6 @@ import {
   useRevokeAccessMutation,
 } from '../queries/use-collaboration-queries.ts'
 import {
-  type RepositoryPermissions,
   formatCollaboratorName,
   getPermissionLevel,
   validateDid,
@@ -32,10 +31,6 @@ export function CollaborationModal({
     'collaborators',
   )
   const [userDid, setUserDid] = useState('')
-  const [permissions, setPermissions] = useState<RepositoryPermissions>({
-    read: true,
-    write: false,
-  })
   const [selectedRole, setSelectedRole] = useState<
     'viewer' | 'contributor' | 'admin'
   >('viewer')
@@ -45,17 +40,35 @@ export function CollaborationModal({
     viewer: {
       name: 'Viewer',
       description: 'Can view repository content',
-      permissions: { read: true, write: false, admin: false },
+      permissions: {
+        read: true,
+        create: false,
+        update: false,
+        delete: false,
+        admin: false,
+      },
     },
     contributor: {
       name: 'Contributor',
       description: 'Can view and modify repository content',
-      permissions: { read: true, write: true, admin: false },
+      permissions: {
+        read: true,
+        create: true,
+        update: true,
+        delete: true,
+        admin: false,
+      },
     },
     admin: {
       name: 'Admin',
       description: 'Full access including user management',
-      permissions: { read: true, write: true, admin: true },
+      permissions: {
+        read: true,
+        create: true,
+        update: true,
+        delete: true,
+        admin: true,
+      },
     },
   }
 
@@ -90,7 +103,6 @@ export function CollaborationModal({
       // Reset form
       setUserDid('')
       setSelectedRole('viewer')
-      setPermissions({ read: true, write: false })
       setActiveTab('collaborators') // Switch back to collaborators tab
     } catch (error) {
       console.error('Failed to grant access:', error)


### PR DESCRIPTION
Without this patch, the collaboration modal in sds-demo uses the old read/write permission model when granting access to collaborators.

This is a problem because commit d2e0b12e16cbe7a3a1ea0378cd18de15f2d946ec updated the `grantAccess` lexicon to require granular permissions (read, create, update, delete) instead of the write boolean. When users attempt to add collaborators via the UI, the API returns HTTP 400 with error `Input/permissions must have the property "create"`.

This patch solves the problem by updating the collaboration modal to use the granular permission model. Role definitions (viewer, contributor, admin) now specify create, update, and delete permissions instead of a single write boolean. Also removes unused permissions state variable and `RepositoryPermissions` import that are no longer needed.

Co-authored-by: Composer <noreply@cursor.com>