### PR TITLE
feat(oauth): add client branding support for OAuth authorization pages

### DIFF
--- a/packages/oauth/oauth-provider/src/customization/build-customization-css.ts
+++ b/packages/oauth/oauth-provider/src/customization/build-customization-css.ts
@@ -1,3 +1,4 @@
+import { OAuthClientMetadata } from '@atproto/oauth-types'
 import { extractHue, pickContrastColor } from '../lib/util/color.js'
 import { Branding } from './branding.js'
 import { COLOR_NAMES } from './colors.js'
@@ -5,9 +6,33 @@ import { Customization } from './customization.js'
 
 export function buildCustomizationCss({
   branding,
-}: Customization): undefined | string {
+  clientMetadata,
+  isTrusted,
+}: Customization & {
+  clientMetadata?: OAuthClientMetadata
+  isTrusted?: boolean
+}): undefined | string {
+  // Build CSS variables from PDS branding
   const vars = Array.from(buildCustomizationVars(branding))
-  if (vars.length) return `:root { ${vars.join(' ')} }`
+
+  // Get arbitrary CSS from trusted clients only
+  const customCss =
+    isTrusted && clientMetadata?.branding?.css
+      ? clientMetadata.branding.css
+      : undefined
+
+  // Build the final CSS string
+  const cssParts: string[] = []
+
+  if (vars.length) {
+    cssParts.push(`:root { ${vars.join(' ')} }`)
+  }
+
+  if (customCss) {
+    cssParts.push(customCss)
+  }
+
+  return cssParts.length > 0 ? cssParts.join('\n') : undefined
 }
 
 function* buildCustomizationVars(branding?: Branding): Generator<string> {

--- a/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
+++ b/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
@@ -14,7 +14,6 @@ import { setupCsrfToken } from './csrf.js'
 export function sendAuthorizePageFactory(customization: Customization) {
   // Pre-computed options:
   const customizationData = buildCustomizationData(customization)
-  const customizationCss = cssCode(buildCustomizationCss(customization))
   const { scripts, styles } = getAssets('authorization-page')
   const csp = mergeCsp(
     SPA_CSP,
@@ -32,6 +31,15 @@ export function sendAuthorizePageFactory(customization: Customization) {
     data: AuthorizationResultAuthorizePage,
   ): Promise<void> {
     await setupCsrfToken(req, res)
+
+    // Generate CSS with client branding
+    const customizationCss = cssCode(
+      buildCustomizationCss({
+        branding: customization.branding,
+        clientMetadata: data.client.metadata,
+        isTrusted: data.client.info.isTrusted,
+      }),
+    )
 
     const script = declareHydrationData<HydrationData['authorization-page']>({
       __customizationData: customizationData,

--- a/packages/oauth/oauth-types/src/oauth-client-metadata.ts
+++ b/packages/oauth/oauth-types/src/oauth-client-metadata.ts
@@ -74,6 +74,23 @@ export const oauthClientMetadataSchema = z.object({
 
   // https://datatracker.ietf.org/doc/html/rfc9396#section-14.5
   authorization_details_types: z.array(z.string()).optional(),
+
+  /**
+   * Client-specific branding configuration
+   * Allows trusted clients to customize the appearance of OAuth authorization pages
+   * via arbitrary CSS. Only used for trusted clients (configured via trustedClients in PDS config)
+   * @see {@link https://github.com/bluesky-social/atproto/blob/main/packages/pds/src/config/config.ts}
+   */
+  branding: z
+    .object({
+      /**
+       * Arbitrary CSS to inject into authorization pages
+       * Only used for trusted clients (configured via trustedClients in PDS config)
+       * @see {@link https://github.com/bluesky-social/atproto/blob/main/packages/pds/src/config/config.ts}
+       */
+      css: z.string().optional(),
+    })
+    .optional(),
 })
 
 export type OAuthClientMetadata = z.infer<typeof oauthClientMetadataSchema>

--- a/packages/sds-demo/rollup.config.js
+++ b/packages/sds-demo/rollup.config.js
@@ -173,6 +173,34 @@ module.exports = defineConfig((commandLineArguments) => {
             application_type: 'web',
             token_endpoint_auth_method: 'none',
             dpop_bound_access_tokens: true,
+            // Custom branding for trusted clients
+            // This CSS will be injected into the authorization page when this client is trusted
+            branding: {
+              css: `
+/* SDS Demo Custom Branding */
+:root {
+  --branding-color-primary: 99 102 241;
+  --branding-color-primary-contrast: 255 255 255;
+  --branding-color-primary-hue: 239;
+}
+
+/* Custom button styling */
+button[type="submit"] {
+  background: linear-gradient(135deg, rgb(99 102 241) 0%, rgb(139 92 246) 100%) !important;
+  box-shadow: 0 4px 14px 0 rgba(99, 102, 241, 0.39) !important;
+}
+
+/* Add a subtle brand indicator */
+.auth-form::before {
+  content: "Powered by SDS Demo";
+  display: block;
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgb(99 102 241);
+  margin-bottom: 1rem;
+}
+              `.trim(),
+            },
           }
 
           this.emitFile({


### PR DESCRIPTION
Without this patch, OAuth clients cannot customize the appearance of
authorization pages when users authenticate. All clients see the same
default Bluesky branding regardless of their identity.

This is a problem because trusted third-party applications (like the
SDS demo) may want to provide a branded experience during the OAuth
flow to maintain visual consistency and user trust.

This patch solves the problem by:
- Adding a `branding.css` field to OAuth client metadata schema
- Allowing trusted clients (configured in PDS trustedClients) to inject
  custom CSS into authorization pages
- Enhancing sds-demo to include example branding CSS

The branding CSS is only applied for clients marked as trusted in the
PDS configuration, preventing untrusted clients from manipulating the
authorization UI.

Co-authored-by: Claude <noreply@anthropic.com>