### PR TITLE
ci: disable cancel-in-progress in CI matrix

### DIFF
--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
We want to be able to see all failures at once rather than fixing one, re-running CI to see the next, fixing that, and so on which is ridiculously inefficient.