### PR TITLE
feat(sds): add com.sds.repo.uploadBlob lexicon with repo param

### DIFF
--- a/lexicons/com/sds/repo/uploadBlob.json
+++ b/lexicons/com/sds/repo/uploadBlob.json
@@ -1,0 +1,44 @@
+{
+  "lexicon": 1,
+  "id": "com.sds.repo.uploadBlob",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Upload a new blob to a shared repository. The blob will be deleted if it is not referenced within a time window (eg, minutes). Blob restrictions (mimetype, size, etc) are enforced when the reference is created. Requires auth and write permissions on the target repository.",
+      "parameters": {
+        "type": "params",
+        "required": ["repo"],
+        "properties": {
+          "repo": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "The handle or DID of the repository to upload the blob to."
+          }
+        }
+      },
+      "input": {
+        "encoding": "*/*"
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["blob"],
+          "properties": {
+            "blob": { "type": "blob" }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "RepositoryNotFound",
+          "description": "The specified repository could not be found."
+        },
+        {
+          "name": "InsufficientPermissions",
+          "description": "The authenticated user does not have write permission on this repository."
+        }
+      ]
+    }
+  }
+}

--- a/packages/sds/src/api/com/sds/repo/uploadBlob.ts
+++ b/packages/sds/src/api/com/sds/repo/uploadBlob.ts
@@ -4,7 +4,8 @@ import { Server } from '../../../../lexicon'
 import { SdsAppContext } from '../../../../sds-context'
 
 export default function (server: Server, ctx: SdsAppContext) {
-  server.com.atproto.repo.uploadBlob({
+  // Register the SDS-specific uploadBlob endpoint that requires a repo parameter
+  server.com.sds.repo.uploadBlob({
     auth: ctx.authVerifier.authorization({
       checkTakedown: false, // Will be checked per-repo in handler
       authorize: (permissions, { req }) => {
@@ -19,109 +20,52 @@ export default function (server: Server, ctx: SdsAppContext) {
         calcPoints: () => 1000,
       },
     ],
-    handler: async ({ auth, input, req }) => {
+    handler: async ({ auth, input, params }) => {
       const userDid = auth.credentials.did
+      const { repo } = params
 
       console.log(
-        `[uploadBlob] Handler entry - User: ${userDid}, Content-Type: ${input.encoding}`,
+        `[uploadBlob] Handler entry - User: ${userDid}, Repo: ${repo}, Content-Type: ${input.encoding}`,
       )
 
-      // SDS Enhancement: Support uploading blobs to shared repositories
-      // If 'repo' query parameter is provided, upload to that repository
-      // Otherwise, upload to the authenticated user's repository (standard behavior)
-      // Note: We access req.query directly since 'repo' is not in the lexicon QueryParams
-      const repoParam =
-        typeof req.query?.repo === 'string' ? req.query.repo : undefined
-
-      if (repoParam) {
-        console.log(
-          `[uploadBlob] Repo parameter detected: ${repoParam}, will check shared access`,
-        )
-      }
+      // Check permissions for shared repository access
+      // Blob uploads require 'create' permission (aligned with OAuth scope model)
+      console.log(
+        `[uploadBlob] Checking permissions for user ${userDid} to access repository ${repo}`,
+      )
 
       let repoDid: string
-      let accessType: 'owner' | 'shared' = 'owner'
+      let accessType: 'owner' | 'shared'
 
-      if (repoParam) {
-        // SDS-specific: Check permissions for shared repository access
-        // Blob uploads require 'create' permission (aligned with OAuth scope model)
+      try {
+        const { account, accessType: access } =
+          await ctx.authVerifier.findAccountWithSharedAccess(
+            repo,
+            userDid,
+            'create',
+            {
+              checkDeactivated: true,
+              checkTakedown: true,
+            },
+          )
+        repoDid = account.did
+        accessType = access
+
         console.log(
-          `[uploadBlob] Checking permissions for user ${userDid} to access repository ${repoParam}`,
+          `[uploadBlob] Permission check succeeded - Access type: ${accessType}, Repository DID: ${repoDid}`,
         )
 
-        try {
-          const { account, accessType: access } =
-            await ctx.authVerifier.findAccountWithSharedAccess(
-              repoParam,
-              userDid,
-              'create',
-              {
-                checkDeactivated: true,
-                checkTakedown: true,
-              },
-            )
-          repoDid = account.did
-          accessType = access
-
+        if (accessType === 'shared') {
           console.log(
-            `[uploadBlob] Permission check succeeded - Access type: ${accessType}, Repository DID: ${repoDid}`,
+            `[uploadBlob] Shared repository access: User ${userDid} uploading blob to repository ${repoDid}`,
           )
-
-          // Log shared repository access for audit purposes
-          if (accessType === 'shared') {
-            console.log(
-              `[uploadBlob] Shared repository access: User ${userDid} uploading blob to repository ${repoDid}`,
-            )
-          }
-        } catch (err) {
-          console.error(
-            `[uploadBlob] Permission check failed for user ${userDid} to access repository ${repoParam}:`,
-            err,
-          )
-          throw err
         }
-      } else {
-        // Standard behavior: upload to authenticated user's repository
-        console.log(
-          `[uploadBlob] No repo parameter, using authenticated user's repository`,
+      } catch (err) {
+        console.error(
+          `[uploadBlob] Permission check failed for user ${userDid} to access repository ${repo}:`,
+          err,
         )
-
-        try {
-          const account = await ctx.authVerifier.findAccount(userDid, {
-            checkDeactivated: true,
-            checkTakedown: true,
-          })
-          repoDid = account.did
-
-          console.log(
-            `[uploadBlob] Account found for user ${userDid}, DID: ${repoDid}`,
-          )
-        } catch (err) {
-          console.error(
-            `[uploadBlob] Failed to find account for user ${userDid}:`,
-            err,
-          )
-          throw err
-        }
-      }
-
-      // OAuth permission checks (same as original PDS)
-      if (auth.credentials.type === 'oauth' && auth.credentials.permissions) {
-        console.log(
-          `[uploadBlob] Performing OAuth permission check for MIME type: ${input.encoding}`,
-        )
-
-        try {
-          const encoding = parseReqEncoding(req)
-          auth.credentials.permissions.assertBlob({ mime: encoding })
-          console.log(`[uploadBlob] OAuth permission check passed`)
-        } catch (err) {
-          console.error(
-            `[uploadBlob] OAuth permission check failed for MIME type ${input.encoding}:`,
-            err,
-          )
-          throw err
-        }
+        throw err
       }
 
       console.log(`[uploadBlob] Starting blob upload for repository ${repoDid}`)

--- a/packages/sds/src/lexicon/index.ts
+++ b/packages/sds/src/lexicon/index.ts
@@ -208,6 +208,7 @@ import * as ComSdsRepoGrantAccess from './types/com/sds/repo/grantAccess.js'
 import * as ComSdsRepoListCollaborators from './types/com/sds/repo/listCollaborators.js'
 import * as ComSdsRepoRevokeAccess from './types/com/sds/repo/revokeAccess.js'
 import * as ComSdsRepoTransferOwnership from './types/com/sds/repo/transferOwnership.js'
+import * as ComSdsRepoUploadBlob from './types/com/sds/repo/uploadBlob.js'
 import * as ToolsOzoneCommunicationCreateTemplate from './types/tools/ozone/communication/createTemplate.js'
 import * as ToolsOzoneCommunicationDeleteTemplate from './types/tools/ozone/communication/deleteTemplate.js'
 import * as ToolsOzoneCommunicationListTemplates from './types/tools/ozone/communication/listTemplates.js'
@@ -3066,6 +3067,18 @@ export class ComSdsRepoNS {
     >,
   ) {
     const nsid = 'com.sds.repo.transferOwnership' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  uploadBlob<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ComSdsRepoUploadBlob.QueryParams,
+      ComSdsRepoUploadBlob.HandlerInput,
+      ComSdsRepoUploadBlob.HandlerOutput
+    >,
+  ) {
+    const nsid = 'com.sds.repo.uploadBlob' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 }

--- a/packages/sds/src/lexicon/lexicons.ts
+++ b/packages/sds/src/lexicon/lexicons.ts
@@ -14378,6 +14378,55 @@ export const schemaDict = {
       },
     },
   },
+  ComSdsRepoUploadBlob: {
+    lexicon: 1,
+    id: 'com.sds.repo.uploadBlob',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Upload a new blob to a shared repository. The blob will be deleted if it is not referenced within a time window (eg, minutes). Blob restrictions (mimetype, size, etc) are enforced when the reference is created. Requires auth and write permissions on the target repository.',
+        parameters: {
+          type: 'params',
+          required: ['repo'],
+          properties: {
+            repo: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'The handle or DID of the repository to upload the blob to.',
+            },
+          },
+        },
+        input: {
+          encoding: '*/*',
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['blob'],
+            properties: {
+              blob: {
+                type: 'blob',
+              },
+            },
+          },
+        },
+        errors: [
+          {
+            name: 'RepositoryNotFound',
+            description: 'The specified repository could not be found.',
+          },
+          {
+            name: 'InsufficientPermissions',
+            description:
+              'The authenticated user does not have write permission on this repository.',
+          },
+        ],
+      },
+    },
+  },
   ToolsOzoneCommunicationCreateTemplate: {
     lexicon: 1,
     id: 'tools.ozone.communication.createTemplate',
@@ -19256,6 +19305,7 @@ export const ids = {
   ComSdsRepoListCollaborators: 'com.sds.repo.listCollaborators',
   ComSdsRepoRevokeAccess: 'com.sds.repo.revokeAccess',
   ComSdsRepoTransferOwnership: 'com.sds.repo.transferOwnership',
+  ComSdsRepoUploadBlob: 'com.sds.repo.uploadBlob',
   ToolsOzoneCommunicationCreateTemplate:
     'tools.ozone.communication.createTemplate',
   ToolsOzoneCommunicationDefs: 'tools.ozone.communication.defs',

--- a/packages/sds/src/lexicon/types/com/sds/repo/uploadBlob.ts
+++ b/packages/sds/src/lexicon/types/com/sds/repo/uploadBlob.ts
@@ -1,0 +1,45 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import stream from 'node:stream'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'com.sds.repo.uploadBlob'
+
+export type QueryParams = {
+  /** The handle or DID of the repository to upload the blob to. */
+  repo: string
+}
+export type InputSchema = string | Uint8Array | Blob
+
+export interface OutputSchema {
+  blob: BlobRef
+}
+
+export interface HandlerInput {
+  encoding: '*/*'
+  body: stream.Readable
+}
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+  error?: 'RepositoryNotFound' | 'InsufficientPermissions'
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess


### PR DESCRIPTION
Add SDS-specific blob upload lexicon that requires a repo parameter,
enabling explicit targeting of shared repositories for blob uploads.
The handler already supports this via req.query.repo access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a write-path API surface and its authorization flow for blob uploads in SDS; mistakes could allow unintended repo targeting or break existing clients expecting the previous optional behavior.
> 
> **Overview**
> Adds a new SDS XRPC procedure, `com.sds.repo.uploadBlob`, whose lexicon *requires* a `repo` parameter so clients can explicitly target a shared repository for blob uploads.
> 
> Updates the SDS upload handler to register this new endpoint (instead of `com.atproto.repo.uploadBlob`) and to always resolve/authorize the target repo via `findAccountWithSharedAccess(repo, userDid, 'create')` before writing the blob, removing the prior optional `req.query.repo` behavior. Generated lexicon bindings are updated to expose the new method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53d8c9c49e9de2218fd8386a2666037f9fd0393c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->